### PR TITLE
Remove `sassc` from gem runtime dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,10 @@ Encoding.default_internal = Encoding::UTF_8
 
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}" }
-
+gem 'isodoc',
+    git: 'https://github.com/metanorma/isodoc.git',
+    branch: 'feature/sassc-gem-dependecey-removal',
+    ref: '536191fb46f9334e749bb56579901d784b25b751'
 gemspec
 
 if File.exist? 'Gemfile.devel'

--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,7 @@ Encoding.default_internal = Encoding::UTF_8
 
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}" }
-gem 'isodoc',
-    git: 'https://github.com/metanorma/isodoc.git',
-    branch: 'feature/sassc-gem-dependecey-removal',
-    ref: '536191fb46f9334e749bb56579901d784b25b751'
+
 gemspec
 
 if File.exist? 'Gemfile.devel'

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+require 'isodoc/gem_tasks'
 
+IsoDoc::GemTasks.install
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec

--- a/metanorma-itu.gemspec
+++ b/metanorma-itu.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "htmlentities", "~> 4.3.4"
   spec.add_dependency "ruby-jing"
   spec.add_dependency "metanorma-standoc", "~> 1.4.0"
-  # spec.add_dependency "isodoc", "~> 1.1.0"
+  spec.add_dependency "isodoc", "~> 1.1.0"
 
   spec.add_development_dependency "byebug", "~> 9.1"
   spec.add_development_dependency "sassc", "2.4.0"

--- a/metanorma-itu.gemspec
+++ b/metanorma-itu.gemspec
@@ -27,9 +27,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency "htmlentities", "~> 4.3.4"
   spec.add_dependency "ruby-jing"
   spec.add_dependency "metanorma-standoc", "~> 1.4.0"
-  spec.add_dependency "isodoc", "~> 1.1.0"
+  # spec.add_dependency "isodoc", "~> 1.1.0"
 
   spec.add_development_dependency "byebug", "~> 9.1"
+  spec.add_development_dependency "sassc", "2.4.0"
   spec.add_development_dependency "equivalent-xml", "~> 0.6"
   spec.add_development_dependency "guard", "~> 2.14"
   spec.add_development_dependency "guard-rspec", "~> 4.7"


### PR DESCRIPTION
metanorma/metanorma#109 moved sassc gem to dev dependency, temporary added isodoc to Gemfile, added rake build script override.