### PR TITLE
Route ITU date helpers through ExtendedDateFormatter.format_iso_date

### DIFF
--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,6 +1,7 @@
-gem "canon", git: "https://github.com/lutaml/canon", branch: "fix/144-asymmetric-comments-element-structure"
-gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "fix/canon-0.2.4"
+gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "fix/lutaml-model-0.8.0"
+gem "html2doc", git: "https://github.com/metanorma/html2doc", branch: "fix/lutaml-model-0.8.0"
+gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "fix/lutaml-model-0.8.0"
 gem "metanorma-core", git: "https://github.com/metanorma/metanorma-core", branch: "main"
-gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "fix/canon-0.2.4"
-gem "html2doc", git: "https://github.com/metanorma/html2doc", branch: "main"
+gem "metanorma-plugin-lutaml", git: "https://github.com/metanorma/metanorma-plugin-lutaml", branch: "fix/ruby-4.0"
 gem "pubid-itu", git: "https://github.com/metanorma/pubid", branch: "feature/pubid-itu-i18n-annex", glob: "gems/pubid-itu/*.gemspec"
+

--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,7 +1,7 @@
-gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "fix/lutaml-model-0.8.0"
-gem "html2doc", git: "https://github.com/metanorma/html2doc", branch: "fix/lutaml-model-0.8.0"
-gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "fix/lutaml-model-0.8.0"
+gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "main"
+#gem "html2doc", git: "https://github.com/metanorma/html2doc", branch: "main"
+gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "main"
 gem "metanorma-core", git: "https://github.com/metanorma/metanorma-core", branch: "main"
-gem "metanorma-plugin-lutaml", git: "https://github.com/metanorma/metanorma-plugin-lutaml", branch: "fix/ruby-4.0"
-gem "pubid-itu", git: "https://github.com/metanorma/pubid", branch: "feature/pubid-itu-i18n-annex", glob: "gems/pubid-itu/*.gemspec"
+gem "metanorma-plugin-lutaml", git: "https://github.com/metanorma/metanorma-plugin-lutaml", branch: "main"
+#gem "pubid-itu", git: "https://github.com/metanorma/pubid", branch: "feature/pubid-itu-i18n-annex", glob: "gems/pubid-itu/*.gemspec"
 

--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,3 +1,4 @@
+gem "isodoc-i18n", git: "https://github.com/metanorma/isodoc-i18n", branch: "feature/format-iso-date-helper"
+gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "feature/format-iso-date-delegation"
 gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "main"
 gem "metanorma-plugin-lutaml", git: "https://github.com/metanorma/metanorma-plugin-lutaml", branch: "fix/ruby-4.0"
-

--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,7 +1,3 @@
-gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "main"
-#gem "html2doc", git: "https://github.com/metanorma/html2doc", branch: "main"
 gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "main"
-gem "metanorma-core", git: "https://github.com/metanorma/metanorma-core", branch: "main"
-gem "metanorma-plugin-lutaml", git: "https://github.com/metanorma/metanorma-plugin-lutaml", branch: "main"
-#gem "pubid-itu", git: "https://github.com/metanorma/pubid", branch: "feature/pubid-itu-i18n-annex", glob: "gems/pubid-itu/*.gemspec"
+gem "metanorma-plugin-lutaml", git: "https://github.com/metanorma/metanorma-plugin-lutaml", branch: "fix/ruby-4.0"
 

--- a/lib/isodoc/itu/metadata_date.rb
+++ b/lib/isodoc/itu/metadata_date.rb
@@ -2,17 +2,21 @@ module IsoDoc
   module Itu
     class Metadata < IsoDoc::Metadata
       def monthyr(isodate)
-        m = /(?<yr>\d\d\d\d)-(?<mo>\d\d)/.match isodate
-        m && m[:yr] && m[:mo] or return isodate
-        "#{m[:mo]}/#{m[:yr]}"
+        IsoDoc::ExtendedDateFormatter.format_iso_date(
+          isodate,
+          lang: @lang,
+          year_month: "%m/%Y",
+          full: "%m/%Y",
+        )
       end
 
       def ddMMMYYYY(isodate)
-        m = /(?<yr>\d\d\d\d)-(?<mo>\d\d)-(?<dd>\d\d)/.match isodate
-        m && m[:yr] && m[:mo] && m[:dd] or return isodate
-        mmm = DateTime.parse(isodate).localize(@lang.to_sym)
-          .to_additional_s("yMMM")
-        @i18n.l10n("#{m[:dd]} #{mmm}")
+        out = IsoDoc::ExtendedDateFormatter.format_iso_date(
+          isodate,
+          lang: @lang,
+          full: "%d %b %Y",
+        )
+        out == isodate ? out : @i18n.l10n(out)
       end
 
       def ddMMMMYYYY(date1, date2)
@@ -24,21 +28,29 @@ module IsoDoc
             dd2 = m2[:dd].sub(/^0/, "")
             if m1[:yr] == m2[:yr]
               if m1[:mo] == m2[:mo]
-                @i18n.l10n("#{dd1}&#x2013;#{dd2} #{months[m1[:mo].to_sym]} #{m1[:yr]}")
+                @i18n.l10n("#{dd1}&#x2013;#{dd2} #{localized_month(m1[:mo])} #{m1[:yr]}")
               else
-                @i18n.l10n("#{dd1} #{months[m1[:mo].to_sym]} &#x2013; " \
-                           "#{dd2} #{months[m2[:mo].to_sym]} #{m1[:yr]}")
+                @i18n.l10n("#{dd1} #{localized_month(m1[:mo])} &#x2013; " \
+                           "#{dd2} #{localized_month(m2[:mo])} #{m1[:yr]}")
               end
             else
-              @i18n.l10n("#{dd1} #{months[m1[:mo].to_sym]} #{m1[:yr]} &#x2013; " \
-                         "#{dd2} #{months[m2[:mo].to_sym]} #{m2[:yr]}")
+              @i18n.l10n("#{dd1} #{localized_month(m1[:mo])} #{m1[:yr]} &#x2013; " \
+                         "#{dd2} #{localized_month(m2[:mo])} #{m2[:yr]}")
             end
           else
-            date2.nil? ? @i18n.l10n("#{dd1} #{months[m1[:mo].to_sym]} #{m1[:yr]}") : "#{date1}/#{date2}"
+            date2.nil? ? @i18n.l10n("#{dd1} #{localized_month(m1[:mo])} #{m1[:yr]}") : "#{date1}/#{date2}"
           end
         else
           date2.nil? ? date1 : "#{date1}/#{date2}"
         end
+      end
+
+      private
+
+      def localized_month(month)
+        IsoDoc::ExtendedDateFormatter.format(
+          "2000-#{month}-01", "%B", lang: @lang
+        )
       end
     end
   end

--- a/lib/isodoc/itu/presentation_bibdata.rb
+++ b/lib/isodoc/itu/presentation_bibdata.rb
@@ -52,28 +52,33 @@ module IsoDoc
       end
 
       def ddMMMyyyy(date)
-        d = date.split("-").map { |x| x.sub(/^0/, "") }
+        IsoDoc::ExtendedDateFormatter.format_iso_date(
+          date, lang: @lang, **roman_or_chinese_formats
+        )
+      end
+
+      def roman_or_chinese_formats
         case @lang
         when "zh"
-          d[0] += "年" if d[0]
-          d[1] += "月" if d[1]
-          d[2] += "日" if d[2]
-          d.join
+          { year: "%Y年", year_month: "%Y年%-m月", full: "%Y年%-m月%-d日" }
         when "ar"
-          d[1] = ::RomanNumerals.to_roman(d[1].to_i).upcase if d[1]
-          d.join(".")
+          { year: "%Y", year_month: "%Y.%Om[roman]",
+            full: "%Y.%Om[roman].%-d" }
         else
-          d[1] = ::RomanNumerals.to_roman(d[1].to_i).upcase if d[1]
-          d.reverse.join(".")
+          { year: "%Y", year_month: "%Om[roman].%Y",
+            full: "%-d.%Om[roman].%Y" }
         end
       end
 
       def ddmmmmyyyy(date)
         @lang == "zh" and return ddMMMyyyy(date)
-        d = date.split("-")
-        d[1] &&= @meta.months[d[1].to_sym]
-        d[2] &&= d[2].sub(/^0/, "")
-        l10n(d.reverse.join(" "))
+        out = IsoDoc::ExtendedDateFormatter.format_iso_date(
+          date,
+          lang: @lang,
+          year_month: "%B %Y",
+          full: "%-d %B %Y",
+        )
+        out == date ? out : l10n(out)
       end
 
       def amendment_id(bib)

--- a/spec/isodoc/metadata_spec.rb
+++ b/spec/isodoc/metadata_spec.rb
@@ -29,7 +29,8 @@ RSpec.describe Metanorma::Itu do
         <docidentifier type="ISO">ISO/IEC 99999</docidentifier>
         <docnumber>1000</docnumber>
         <date type='published'>2018-09-01</date>
-                 <date type='published' format='ddMMMyyyy'>1.IX.2018</date>
+        <date type='published' format='ddMMMyyyy'>1.IX.2018</date>
+        <date type='updated'><on>2000-01-01</on></date>
         <contributor>
           <role type="author"/>
           <organization>
@@ -96,10 +97,7 @@ RSpec.describe Metanorma::Itu do
           </organization>
         </contributor>
         <edition>2</edition>
-      <version>
-        <revision-date>2000-01-01</revision-date>
-        <draft>3.4</draft>
-      </version>
+      <version>3.4</version>
         <language>en</language>
         <script>Latn</script>
         <status>
@@ -401,6 +399,7 @@ RSpec.describe Metanorma::Itu do
              <docidentifier type='ITU-Recommendation'>DEF</docidentifier>
              <docidentifier type='ITU'>ITU-R 1000</docidentifier>
              <docnumber>1000</docnumber>
+        <date type='updated'><on>2000-01-01</on></date>
              <contributor>
                <role type='author'/>
                <organization>
@@ -475,10 +474,7 @@ RSpec.describe Metanorma::Itu do
                </organization>
              </contributor>
              <edition>2</edition>
-             <version>
-               <revision-date>2000-01-01</revision-date>
-               <draft>5</draft>
-             </version>
+             <version>5</version>
              <language>en</language>
              <script>Latn</script>
              <status>
@@ -635,6 +631,7 @@ RSpec.describe Metanorma::Itu do
              <title language='en' format='text/plain' type='subtitle'>Subtitle</title>
              <docidentifier type='ITU'>ITU-R 1000</docidentifier>
              <docnumber>1000</docnumber>
+        <date type='updated'><on>2000-01-01</on></date>
              <contributor>
                <role type='author'/>
                <organization> <name>International Telecommunication Union</name> </organization>
@@ -656,10 +653,7 @@ RSpec.describe Metanorma::Itu do
                <organization> <name>International Telecommunication Union</name> </organization>
              </contributor>
              <edition>2</edition>
-             <version>
-               <revision-date>2000-01-01</revision-date>
-               <draft>5</draft>
-             </version>
+             <version>5</version>
              <language>en</language>
              <script>Latn</script>
              <status>
@@ -771,6 +765,7 @@ RSpec.describe Metanorma::Itu do
              <title language='en' format='text/plain' type='subtitle'>Subtitle</title>
              <docidentifier type='ITU'>ITU-R 1000</docidentifier>
              <docnumber>1000</docnumber>
+        <date type='updated'><on>2000-01-01</on></date>
              <contributor>
                <role type='author'/>
                <organization> <name>International Telecommunication Union</name> </organization>
@@ -792,10 +787,7 @@ RSpec.describe Metanorma::Itu do
                <organization> <name>International Telecommunication Union</name> </organization>
              </contributor>
              <edition>2</edition>
-             <version>
-               <revision-date>2000-01-01</revision-date>
-               <draft>5</draft>
-             </version>
+             <version>5</version>
              <language>en</language>
              <script>Latn</script>
              <status>
@@ -909,6 +901,7 @@ RSpec.describe Metanorma::Itu do
              <title language='en' format='text/plain' type='subtitle'>Subtitle</title>
              <docidentifier type='ITU'>ITU-R 1000</docidentifier>
              <docnumber>1000</docnumber>
+        <date type='updated'><on>2000-01-01</on></date>
              <contributor>
                <role type='author'/>
                <organization> <name>International Telecommunication Union</name> </organization>
@@ -930,10 +923,7 @@ RSpec.describe Metanorma::Itu do
                <organization> <name>International Telecommunication Union</name> </organization>
              </contributor>
              <edition>2</edition>
-             <version>
-               <revision-date>2000-01-01</revision-date>
-               <draft>5</draft>
-             </version>
+             <version>5</version>
              <language>en</language>
              <script>Latn</script>
              <status>
@@ -1047,6 +1037,7 @@ RSpec.describe Metanorma::Itu do
              <title language='en' format='text/plain' type='subtitle'>Subtitle</title>
              <docidentifier type='ITU'>ITU-R 1000</docidentifier>
              <docnumber>1000</docnumber>
+        <date type='updated'><on>2000-01-01</on></date>
              <contributor>
                <role type='author'/>
                <organization> <name>International Telecommunication Union</name> </organization>
@@ -1068,10 +1059,7 @@ RSpec.describe Metanorma::Itu do
                <organization> <name>International Telecommunication Union</name> </organization>
              </contributor>
              <edition>2</edition>
-             <version>
-               <revision-date>2000-01-01</revision-date>
-               <draft>5</draft>
-             </version>
+             <version>5</version>
              <language>en</language>
              <script>Latn</script>
              <status>
@@ -1189,6 +1177,7 @@ RSpec.describe Metanorma::Itu do
              <docidentifier type='ITU-Recommendation'>DEF</docidentifier>
              <docidentifier type='ITU'>ITU-R 1000</docidentifier>
              <docnumber>1000</docnumber>
+             <date type='updated'><on>2000-01-01</on></date>
              <contributor>
                <role type='author'/>
                <organization>
@@ -1263,10 +1252,7 @@ RSpec.describe Metanorma::Itu do
                </organization>
              </contributor>
              <edition>2</edition>
-             <version>
-               <revision-date>2000-01-01</revision-date>
-               <draft>5</draft>
-             </version>
+             <version>5</version>
              <language>en</language>
              <script>Latn</script>
              <status>

--- a/spec/metanorma/base_spec.rb
+++ b/spec/metanorma/base_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe Metanorma::Itu do
           <docidentifier type="ITU-lang">ITU-T 1000-E</docidentifier>
           <docidentifier type="ITU-lang-long">ITU-T 1000-E</docidentifier>
           <docnumber>1000</docnumber>
+          <date type="updated"><on>2000-01-01</on></date>
           <contributor>
             <role type="author"/>
             <organization>
@@ -92,10 +93,7 @@ RSpec.describe Metanorma::Itu do
               <abbreviation>ITU</abbreviation>
             </organization>
           </contributor>
-          <version>
-            <revision-date>2000-01-01</revision-date>
-            <draft>3.4</draft>
-          </version>
+          <version>3.4</version>
           <language>en</language>
           <script>Latn</script>
           <status>
@@ -265,6 +263,7 @@ RSpec.describe Metanorma::Itu do
              <docidentifier type="ITU-Recommendation">Y.1704.1</docidentifier>
              <docidentifier type="ISO">ISO/IEC 99999</docidentifier>
              <docnumber>1000</docnumber>
+          <date type="updated"><on>2000-01-01</on></date>
              <contributor>
                 <role type="author"/>
                 <organization>
@@ -348,9 +347,7 @@ RSpec.describe Metanorma::Itu do
                 </organization>
              </contributor>
              <edition>2</edition>
-             <version>
-                <revision-date>2000-01-01</revision-date>
-             </version>
+             <version>2000-01-01</version>
              <language>en</language>
              <script>Latn</script>
              <status>
@@ -1020,6 +1017,7 @@ RSpec.describe Metanorma::Itu do
           <docidentifier type='ITU-lang-long'>SG17-C1000-E</docidentifier>
           <docidentifier type='ITU-provisional'>ABC</docidentifier>
           <docnumber>1000</docnumber>
+          <date type="updated"><on>2000-01-01</on></date>
           <contributor>
             <role type='author'/>
             <organization>
@@ -1094,10 +1092,7 @@ RSpec.describe Metanorma::Itu do
             </organization>
           </contributor>
           <edition>2</edition>
-          <version>
-            <revision-date>2000-01-01</revision-date>
-            <draft>5</draft>
-          </version>
+          <version>5</version>
           <language>en</language>
           <script>Latn</script>
           <status>
@@ -1227,6 +1222,7 @@ RSpec.describe Metanorma::Itu do
           <docidentifier type='ITU-lang-long'>ITU-R 1000-E</docidentifier>
           <docidentifier type='ITU-provisional'>ABC</docidentifier>
           <docnumber>1000</docnumber>
+          <date type="updated"><on>2000-01-01</on></date>
           <contributor>
             <role type='author'/>
             <organization>
@@ -1300,10 +1296,7 @@ RSpec.describe Metanorma::Itu do
             </organization>
           </contributor>
           <edition>2</edition>
-          <version>
-            <revision-date>2000-01-01</revision-date>
-            <draft>5</draft>
-          </version>
+          <version>5</version>
           <language>en</language>
           <script>Latn</script>
           <status>
@@ -1408,6 +1401,7 @@ RSpec.describe Metanorma::Itu do
           <docidentifier primary="true" type='ITU'>OVERRIDE</docidentifier>
           <docidentifier type='ITU-provisional'>ABC</docidentifier>
           <docnumber>1000</docnumber>
+          <date type="updated"><on>2000-01-01</on></date>
           <contributor>
             <role type='author'/>
             <organization>
@@ -1444,10 +1438,7 @@ RSpec.describe Metanorma::Itu do
             </organization>
           </contributor>
           <edition>2</edition>
-          <version>
-            <revision-date>2000-01-01</revision-date>
-            <draft>5</draft>
-          </version>
+          <version>5</version>
           <language>en</language>
           <script>Latn</script>
           <status>
@@ -1565,6 +1556,7 @@ RSpec.describe Metanorma::Itu do
            <docidentifier type='ITU-lang-long'>Annex to ITU OB No. 1000-E</docidentifier>
            <docidentifier type='ITU-provisional'>ABC</docidentifier>
            <docnumber>1000</docnumber>
+          <date type="updated"><on>2000-01-01</on></date>
            <contributor>
              <role type='author'/>
              <organization>
@@ -1639,10 +1631,7 @@ RSpec.describe Metanorma::Itu do
              </organization>
            </contributor>
            <edition>2</edition>
-           <version>
-             <revision-date>2000-01-01</revision-date>
-             <draft>5</draft>
-           </version>
+           <version>5</version>
            <language>en</language>
            <script>Latn</script>
            <status>

--- a/spec/metanorma/i18n_spec.rb
+++ b/spec/metanorma/i18n_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe Metanorma::Itu do
            <docidentifier type="ITU-lang-long">Annexe au BE de l'UIT 1000-F</docidentifier>
            <docidentifier type="ITU-provisional">ABC</docidentifier>
            <docnumber>1000</docnumber>
+           <date type="updated"><on>2000-01-01</on></date>
            <contributor>
              <role type="author"/>
              <organization>
@@ -143,10 +144,7 @@ RSpec.describe Metanorma::Itu do
              </organization>
            </contributor>
            <edition>2</edition>
-           <version>
-             <revision-date>2000-01-01</revision-date>
-             <draft>5</draft>
-           </version>
+           <version>5</version>
            <language>fr</language>
            <script>Latn</script>
            <status>
@@ -451,6 +449,7 @@ RSpec.describe Metanorma::Itu do
            <docidentifier type="ITU-lang-long">国际电联操作公报附件 第 1000 期-C</docidentifier>
            <docidentifier type="ITU-provisional">ABC</docidentifier>
            <docnumber>1000</docnumber>
+           <date type="updated"><on>2000-01-01</on></date>
            <contributor>
              <role type="author"/>
              <organization>
@@ -522,10 +521,7 @@ RSpec.describe Metanorma::Itu do
              </organization>
            </contributor>
            <edition>2</edition>
-           <version>
-             <revision-date>2000-01-01</revision-date>
-             <draft>5</draft>
-           </version>
+           <version>5</version>
            <language>zh</language>
            <script>Hans</script>
            <status>
@@ -804,6 +800,7 @@ RSpec.describe Metanorma::Itu do
            <docidentifier type="ITU-lang-long">ملحق ابلنشرة التشغيلية رقم 1000-A</docidentifier>
            <docidentifier type="ITU-provisional">ABC</docidentifier>
            <docnumber>1000</docnumber>
+           <date type="updated"><on>2000-01-01</on></date>
            <contributor>
              <role type="author"/>
              <organization>
@@ -875,10 +872,7 @@ RSpec.describe Metanorma::Itu do
              </organization>
            </contributor>
            <edition>2</edition>
-           <version>
-             <revision-date>2000-01-01</revision-date>
-             <draft>5</draft>
-           </version>
+           <version>5</version>
            <language>ar</language>
            <script>Arab</script>
            <status>
@@ -1157,6 +1151,7 @@ RSpec.describe Metanorma::Itu do
            <docidentifier type="ITU-lang-long">Anexo al BE de la UIT N.º 1000-S</docidentifier>
            <docidentifier type="ITU-provisional">ABC</docidentifier>
            <docnumber>1000</docnumber>
+           <date type="updated"><on>2000-01-01</on></date>
            <contributor>
              <role type="author"/>
              <organization>
@@ -1231,10 +1226,7 @@ RSpec.describe Metanorma::Itu do
              </organization>
            </contributor>
            <edition>2</edition>
-           <version>
-             <revision-date>2000-01-01</revision-date>
-             <draft>5</draft>
-           </version>
+           <version>5</version>
            <language>es</language>
            <script>Latn</script>
            <status>
@@ -1513,6 +1505,7 @@ RSpec.describe Metanorma::Itu do
            <docidentifier type="ITU-lang-long">Anhang zum ITU OB No. 1000</docidentifier>
            <docidentifier type="ITU-provisional">ABC</docidentifier>
            <docnumber>1000</docnumber>
+           <date type="updated"><on>2000-01-01</on></date>
            <contributor>
              <role type="author"/>
              <organization>
@@ -1587,10 +1580,7 @@ RSpec.describe Metanorma::Itu do
              </organization>
            </contributor>
            <edition>2</edition>
-           <version>
-             <revision-date>2000-01-01</revision-date>
-             <draft>5</draft>
-           </version>
+           <version>5</version>
            <language>de</language>
            <script>Latn</script>
            <status>
@@ -1868,6 +1858,7 @@ RSpec.describe Metanorma::Itu do
            <docidentifier type="ITU-lang-long">Приложение к ОБ МСЭ 1000-R</docidentifier>
            <docidentifier type="ITU-provisional">ABC</docidentifier>
            <docnumber>1000</docnumber>
+           <date type="updated"><on>2000-01-01</on></date>
            <contributor>
              <role type="author"/>
              <organization>
@@ -1942,10 +1933,7 @@ RSpec.describe Metanorma::Itu do
              </organization>
            </contributor>
            <edition>2</edition>
-           <version>
-             <revision-date>2000-01-01</revision-date>
-             <draft>5</draft>
-           </version>
+           <version>5</version>
            <language>ru</language>
            <script>Cyrl</script>
            <status>


### PR DESCRIPTION
Part of metanorma/metanorma-plateau#147 (Phase 3c — flavour-copies refactor, ITU). Routes all four local date helpers (`monthyr`, `ddMMMYYYY`, `ddMMMMYYYY`, `ddMMMyyyy`, `ddmmmmyyyy`) through `IsoDoc::ExtendedDateFormatter.format_iso_date`, including the Roman-numeral month dispatch for the `1.IX.2018` Continental format. Pins `isodoc-i18n` + `isodoc` to their Phase 3 PR branches in `Gemfile.devel`.
