### PR TITLE
Annotate dl1 gotcha: dl-as-table drops author @class (iso-10303#712)

### DIFF
--- a/lib/isodoc/itu/base_convert.rb
+++ b/lib/isodoc/itu/base_convert.rb
@@ -105,6 +105,14 @@ module IsoDoc
         n = dlist.at(ns("./colgroup")) and ret = "#{n.remove.to_xml}#{ret}"
         n = dlist.at(ns("./fmt-name")) and ret = "#{n.remove.to_xml}#{ret}"
         dlist.name = "table"
+        # GOTCHA (metanorma/iso-10303#712): ITU renders definition lists as
+        # tables, and this hard-sets class="dl", OVERWRITING any author custom
+        # @class ([class="..."]). So the block-@class support added in
+        # metanorma-standoc#1197 does NOT reach dl in ITU. Left as-is
+        # deliberately (class="dl" is the intentional dl-as-table marker); making
+        # it additive would re-enter the dl->table / MsoISOTable-border
+        # interaction. If an author class is ever wanted here, merge instead of
+        # overwrite: ["dl", dlist["class"]].compact.join(" ").
         dlist["class"] = "dl"
         dlist.children.first.previous = ret
       end


### PR DESCRIPTION
Refs https://github.com/metanorma/iso-10303/issues/712

## Summary

Documents a gotcha (no functional change). ITU renders definition lists as tables (`dl1`) and hard-sets `class="dl"`, which **overwrites** any author `[class="…"]`. So the block-`@class` support extended to dl in metanorma/metanorma-standoc#1197 does **not** reach dl under ITU.

Left as-is deliberately: `class="dl"` is the intentional dl-as-table marker, and making it additive would re-enter the dl→table / MsoISOTable-border interaction. The comment records the how-to-fix (`["dl", dlist["class"]].compact.join(" ")`) if an author class is ever wanted here.

## Changes
- `lib/isodoc/itu/base_convert.rb` — gotcha comment on `dl1`.

🤖
