### PR TITLE
keywords: emit structured vocab per grammar, not bare text

### DIFF
--- a/lib/metanorma/itu/basicdoc.rng
+++ b/lib/metanorma/itu/basicdoc.rng
@@ -1527,12 +1527,16 @@ to indicate that the index range covers a range of locations between the current
       <ref name="index-primary">
         <a:documentation>Primary index term to be recorded at the current location</a:documentation>
       </ref>
-      <ref name="index-secondary">
-        <a:documentation>Secondary index term to be recorded at the current location</a:documentation>
-      </ref>
-      <ref name="index-tertiary">
-        <a:documentation>Tertiary index term to be recorded at the current </a:documentation>
-      </ref>
+      <optional>
+        <ref name="index-secondary">
+          <a:documentation>Secondary index term to be recorded at the current location</a:documentation>
+        </ref>
+      </optional>
+      <optional>
+        <ref name="index-tertiary">
+          <a:documentation>Tertiary index term to be recorded at the current </a:documentation>
+        </ref>
+      </optional>
     </element>
   </define>
   <define name="index-xref">
@@ -1547,12 +1551,16 @@ The text in the inline element is the primary index term to be be cross-referenc
       <ref name="index-primary">
         <a:documentation>The primary index term to be cross-referenced</a:documentation>
       </ref>
-      <ref name="index-secondary">
-        <a:documentation>The secondary index term to be cross-referenced</a:documentation>
-      </ref>
-      <ref name="index-tertiary">
-        <a:documentation>The tertiary index term to be cross-referenced</a:documentation>
-      </ref>
+      <optional>
+        <ref name="index-secondary">
+          <a:documentation>The secondary index term to be cross-referenced</a:documentation>
+        </ref>
+      </optional>
+      <optional>
+        <ref name="index-tertiary">
+          <a:documentation>The tertiary index term to be cross-referenced</a:documentation>
+        </ref>
+      </optional>
       <element name="target">
         <a:documentation>The index term to be cross-referenced to</a:documentation>
         <oneOrMore>
@@ -1933,7 +1941,8 @@ or as the string "auto"</a:documentation>
   <define name="mathml">
     <a:documentation>Encoding of MathML: the official W3C MathML 4 grammar (namespace
 http://www.w3.org/1998/Math/MathML), via the metanorma wrapper in
-grammars/mathml/. See grammars/mathml/README.adoc and basicdoc-models#35.</a:documentation>
+grammars/mathml/. See grammars/mathml/README.adoc, basicdoc-models#35,
+and the MathML 3 -&gt; 4 migration: basicdoc-models#39 / metanorma#585.</a:documentation>
     <externalRef href="metanorma-mathml.rng"/>
   </define>
   <define name="StemAttributes">

--- a/lib/metanorma/itu/converter.rb
+++ b/lib/metanorma/itu/converter.rb
@@ -82,8 +82,12 @@ module Metanorma
         node.attr("keywords") or return
         node.attr("keywords").split(/, */).sort.each_with_index do |kw, i|
           kw_out = i.zero? ? Metanorma::Utils.strict_capitalize_first(kw) : kw
-          add_noko_elem(xml, "keyword", kw_out)
-          # xml.keyword kw_out
+          kw_out.empty? and next
+          # keyword content is structured per the grammar: an uncontrolled
+          # keyword is a vocab entry, not bare text
+          xml.keyword do |k|
+            add_noko_elem(k, "vocab", kw_out)
+          end
         end
       end
 

--- a/lib/metanorma/itu/isodoc.rng
+++ b/lib/metanorma/itu/isodoc.rng
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
-<!-- VERSION v2.1.6 -->
+<!-- VERSION v2.2.0 -->
 
   <!--
     ALERT: cannot have root comments, because of https://github.com/metanorma/metanorma/issues/437

--- a/spec/isodoc/metadata_spec.rb
+++ b/spec/isodoc/metadata_spec.rb
@@ -122,8 +122,8 @@ RSpec.describe Metanorma::Itu do
       <series type="tertiary">
         <title>C3</title>
       </series>
-           <keyword>word2</keyword>
-       <keyword>word1</keyword>
+           <keyword><vocab>word2</vocab></keyword>
+       <keyword><vocab>word1</vocab></keyword>
         <ext>
         <doctype>directive</doctype>
             <editorialgroup>
@@ -497,8 +497,8 @@ RSpec.describe Metanorma::Itu do
              <series type='tertiary'>
                <title>C3</title>
              </series>
-             <keyword>Word1</keyword>
-             <keyword>word2</keyword>
+             <keyword><vocab>Word1</vocab></keyword>
+             <keyword><vocab>word2</vocab></keyword>
              <ext>
                <doctype>technical-report</doctype>
                <editorialgroup>
@@ -665,8 +665,8 @@ RSpec.describe Metanorma::Itu do
                  <organization> <name>International Telecommunication Union</name> </organization>
                </owner>
              </copyright>
-             <keyword>Word1</keyword>
-             <keyword>word2</keyword>
+             <keyword><vocab>Word1</vocab></keyword>
+             <keyword><vocab>word2</vocab></keyword>
              <ext>
                <doctype>resolution</doctype>
                <editorialgroup>
@@ -799,8 +799,8 @@ RSpec.describe Metanorma::Itu do
                  <organization> <name>International Telecommunication Union</name> </organization>
                </owner>
              </copyright>
-             <keyword>Word1</keyword>
-             <keyword>word2</keyword>
+             <keyword><vocab>Word1</vocab></keyword>
+             <keyword><vocab>word2</vocab></keyword>
              <ext>
                <doctype>resolution</doctype>
                <editorialgroup>
@@ -935,8 +935,8 @@ RSpec.describe Metanorma::Itu do
                  <organization> <name>International Telecommunication Union</name> </organization>
                </owner>
              </copyright>
-             <keyword>Word1</keyword>
-             <keyword>word2</keyword>
+             <keyword><vocab>Word1</vocab></keyword>
+             <keyword><vocab>word2</vocab></keyword>
              <ext>
                <doctype>resolution</doctype>
                <editorialgroup>
@@ -1071,8 +1071,8 @@ RSpec.describe Metanorma::Itu do
                  <organization> <name>International Telecommunication Union</name> </organization>
                </owner>
              </copyright>
-             <keyword>Word1</keyword>
-             <keyword>word2</keyword>
+             <keyword><vocab>Word1</vocab></keyword>
+             <keyword><vocab>word2</vocab></keyword>
              <ext>
                <doctype>resolution</doctype>
                <editorialgroup>
@@ -1275,8 +1275,8 @@ RSpec.describe Metanorma::Itu do
              <series type='tertiary'>
                <title>C3</title>
              </series>
-             <keyword>Word1</keyword>
-             <keyword>word2</keyword>
+             <keyword><vocab>Word1</vocab></keyword>
+             <keyword><vocab>word2</vocab></keyword>
              <ext>
                <doctype>technical-report</doctype>
                <editorialgroup>

--- a/spec/isodoc/section_spec.rb
+++ b/spec/isodoc/section_spec.rb
@@ -1058,8 +1058,8 @@ RSpec.describe Metanorma::Itu do
              <docidentifier type="ISO">ISO/IEC 99999</docidentifier>
              <language>en</language>
              <script>Latn</script>
-             <keyword>A</keyword>
-             <keyword>B</keyword>
+             <keyword><vocab>A</vocab></keyword>
+             <keyword><vocab>B</vocab></keyword>
              <ext>
              <doctype>recommendation</doctype>
              <flavor>itu</flavor>
@@ -1096,8 +1096,8 @@ RSpec.describe Metanorma::Itu do
              <docidentifier type="ISO">ISO/IEC 99999</docidentifier>
              <language current="true">en</language>
              <script current="true">Latn</script>
-             <keyword>A</keyword>
-             <keyword>B</keyword>
+             <keyword><vocab>A</vocab></keyword>
+             <keyword><vocab>B</vocab></keyword>
              <ext>
                 <doctype language="">recommendation</doctype>
                 <doctype language="en">Recommendation</doctype>
@@ -1528,8 +1528,8 @@ RSpec.describe Metanorma::Itu do
           <series type='tertiary'>
             <title>C3</title>
           </series>
-          <keyword>VoIP</keyword>
-          <keyword>word1</keyword>
+          <keyword><vocab>VoIP</vocab></keyword>
+          <keyword><vocab>word1</vocab></keyword>
           <ext>
           <doctype>contribution</doctype>
             <recommendationstatus>

--- a/spec/isodoc/section_title_spec.rb
+++ b/spec/isodoc/section_title_spec.rb
@@ -569,8 +569,8 @@ RSpec.describe Metanorma::Itu do
                      <title language="en" format="text/plain" type="main">An ITU Standard</title>
                      <docidentifier type="ITU">12345</docidentifier>
                      <language>en</language>
-                     <keyword>A</keyword>
-                     <keyword>B</keyword>
+                     <keyword><vocab>A</vocab></keyword>
+                     <keyword><vocab>B</vocab></keyword>
                      <ext>
                      <doctype>recommendation</doctype>
                      </ext>
@@ -665,8 +665,8 @@ RSpec.describe Metanorma::Itu do
              <title language="en" format="text/plain" type="subtitle">Subtitle</title>
              <docidentifier type="ITU">12345</docidentifier>
              <language>en</language>
-             <keyword>A</keyword>
-             <keyword>B</keyword>
+             <keyword><vocab>A</vocab></keyword>
+             <keyword><vocab>B</vocab></keyword>
              <ext>
              <doctype>recommendation-annex</doctype>
              <structuredidentifier>
@@ -693,8 +693,8 @@ RSpec.describe Metanorma::Itu do
               <title language="en" format="text/plain" type="subtitle">Subtitle</title>
               <docidentifier type="ITU">12345</docidentifier>
               <language current="true">en</language>
-              <keyword>A</keyword>
-              <keyword>B</keyword>
+              <keyword><vocab>A</vocab></keyword>
+              <keyword><vocab>B</vocab></keyword>
               <ext>
                  <doctype language="">recommendation-annex</doctype>
                  <doctype language="en">Recommendation Annex</doctype>

--- a/spec/isodoc/xref_spec.rb
+++ b/spec/isodoc/xref_spec.rb
@@ -553,8 +553,8 @@ OUTPUT
                  <title language="en" format="text/plain" type="main">An ITU Standard</title>
                  <docidentifier type="ITU">12345</docidentifier>
                  <language>en</language>
-                 <keyword>A</keyword>
-                 <keyword>B</keyword>
+                 <keyword><vocab>A</vocab></keyword>
+                 <keyword><vocab>B</vocab></keyword>
                  <ext>
                  <doctype>recommendation-annex</doctype>
                  <structuredidentifier>
@@ -584,8 +584,8 @@ OUTPUT
               <title language="en" format="text/plain" type="main">An ITU Standard</title>
               <docidentifier type="ITU">12345</docidentifier>
               <language current="true">en</language>
-              <keyword>A</keyword>
-              <keyword>B</keyword>
+              <keyword><vocab>A</vocab></keyword>
+              <keyword><vocab>B</vocab></keyword>
               <ext>
                  <doctype language="">recommendation-annex</doctype>
                  <doctype language="en">Recommendation Annex</doctype>

--- a/spec/metanorma/base_spec.rb
+++ b/spec/metanorma/base_spec.rb
@@ -235,620 +235,626 @@ RSpec.describe Metanorma::Itu do
     INPUT
     output = <<~"OUTPUT"
        <metanorma xmlns="https://www.metanorma.org/ns/standoc" type="semantic" version="#{Metanorma::Itu::VERSION}" flavor="itu">
-          <bibdata type="standard">
-             <title language="en" type="main">Main Title</title>
-             <title language="en" type="annex">I3</title>
-             <title language="en" type="title-amendment-prefix">Amendment 88</title>
-             <title language="en" type="title-corrigendum-prefix">Corrigendum 88</title>
-             <title language="fr" type="main">Titre Principal</title>
-             <title language="fr" type="title-amendment-prefix">Amendement 88</title>
-             <title language="fr" type="title-corrigendum-prefix">Rectificatif 88</title>
-             <title language="fr" type="annex">J3</title>
-             <title language="fr" type="title-amendment-prefix">Amendement 88</title>
-             <title language="fr" type="title-corrigendum-prefix">Rectificatif 88</title>
-             <title language="en" type="subtitle">Subtitle</title>
-             <title language="fr" type="subtitle">Soustitre</title>
-             <title language="en" type="amendment">Amendment Title</title>
-             <title language="fr" type="amendment">Titre de Amendment</title>
-             <title language="en" type="corrigendum">Corrigendum Title</title>
-             <title language="fr" type="corrigendum">Titre de Corrigendum</title>
-             <title language="en" type="collection">Articles</title>
-             <title language="en" type="slogan">Slogan</title>
-             <docidentifier type="ITU" primary="true">ITU-R 1000</docidentifier>
-             <docidentifier type="ITU-lang">ITU-R 1000-E</docidentifier>
-             <docidentifier type="ITU-lang-long">ITU-R 1000-E</docidentifier>
-             <docidentifier type="ITU-provisional">ABC</docidentifier>
-             <docidentifier type="ITU-TemporaryDocument">SG17-TD611</docidentifier>
-             <docidentifier type="ITU-Recommendation">G.7713.1</docidentifier>
-             <docidentifier type="ITU-Recommendation">Y.1704.1</docidentifier>
-             <docidentifier type="ISO">ISO/IEC 99999</docidentifier>
-             <docnumber>1000</docnumber>
-          <date type="updated"><on>2000-01-01</on></date>
-             <contributor>
-                <role type="author"/>
-                <organization>
+         <bibdata type="standard">
+           <title language="en" type="main">Main Title</title>
+           <title language="en" type="annex">I3</title>
+           <title language="en" type="title-amendment-prefix">Amendment 88</title>
+           <title language="en" type="title-corrigendum-prefix">Corrigendum 88</title>
+           <title language="fr" type="main">Titre Principal</title>
+           <title language="fr" type="title-amendment-prefix">Amendement 88</title>
+           <title language="fr" type="title-corrigendum-prefix">Rectificatif 88</title>
+           <title language="fr" type="annex">J3</title>
+           <title language="fr" type="title-amendment-prefix">Amendement 88</title>
+           <title language="fr" type="title-corrigendum-prefix">Rectificatif 88</title>
+           <title language="en" type="subtitle">Subtitle</title>
+           <title language="fr" type="subtitle">Soustitre</title>
+           <title language="en" type="amendment">Amendment Title</title>
+           <title language="fr" type="amendment">Titre de Amendment</title>
+           <title language="en" type="corrigendum">Corrigendum Title</title>
+           <title language="fr" type="corrigendum">Titre de Corrigendum</title>
+           <title language="en" type="collection">Articles</title>
+           <title language="en" type="slogan">Slogan</title>
+           <docidentifier type="ITU" primary="true">ITU-R 1000</docidentifier>
+           <docidentifier type="ITU-lang">ITU-R 1000-E</docidentifier>
+           <docidentifier type="ITU-lang-long">ITU-R 1000-E</docidentifier>
+           <docidentifier type="ITU-provisional">ABC</docidentifier>
+           <docidentifier type="ITU-TemporaryDocument">SG17-TD611</docidentifier>
+           <docidentifier type="ITU-Recommendation">G.7713.1</docidentifier>
+           <docidentifier type="ITU-Recommendation">Y.1704.1</docidentifier>
+           <docidentifier type="ISO">ISO/IEC 99999</docidentifier>
+           <docnumber>1000</docnumber>
+           <date type="updated">
+             <on>2000-01-01</on>
+           </date>
+           <contributor>
+             <role type="author"/>
+             <organization>
+               <name>International Telecommunication Union</name>
+               <abbreviation>ITU</abbreviation>
+             </organization>
+           </contributor>
+           <contributor>
+             <role type="author"/>
+             <person>
+               <name>
+                 <completename>Fred Flintstone</completename>
+               </name>
+             </person>
+           </contributor>
+           <contributor>
+             <role type="editor"/>
+             <person>
+               <name>
+                 <forename>Barney</forename>
+                 <surname>Rubble</surname>
+               </name>
+             </person>
+           </contributor>
+           <contributor>
+             <role type="author">
+               <description>committee</description>
+             </role>
+             <organization>
+               <name>International Telecommunication Union</name>
+               <subdivision type="Bureau">
+                 <name>R</name>
+               </subdivision>
+               <subdivision type="Sector">
+                 <name>Sector</name>
+               </subdivision>
+               <subdivision type="Group" subtype="A">
+                 <name>I</name>
+                 <identifier>C</identifier>
+               </subdivision>
+               <subdivision type="Subgroup" subtype="A1">
+                 <name>I1</name>
+                 <identifier>C1</identifier>
+               </subdivision>
+               <subdivision type="Workgroup" subtype="A2">
+                 <name>I2</name>
+                 <identifier>C2</identifier>
+               </subdivision>
+               <abbreviation>ITU</abbreviation>
+             </organization>
+           </contributor>
+           <contributor>
+             <role type="author">
+               <description>committee</description>
+             </role>
+             <organization>
+               <name>International Telecommunication Union</name>
+               <subdivision type="Bureau">
+                 <name>T</name>
+               </subdivision>
+               <subdivision type="Group" subtype="B">
+                 <name>J</name>
+                 <identifier>D</identifier>
+               </subdivision>
+               <subdivision type="Subgroup" subtype="B1">
+                 <name>J1</name>
+                 <identifier>D1</identifier>
+               </subdivision>
+               <subdivision type="Workgroup" subtype="B2">
+                 <name>J2</name>
+                 <identifier>D2</identifier>
+               </subdivision>
+               <abbreviation>ITU</abbreviation>
+             </organization>
+           </contributor>
+           <contributor>
+             <role type="publisher"/>
+             <organization>
+               <name>International Telecommunication Union</name>
+               <abbreviation>ITU</abbreviation>
+             </organization>
+           </contributor>
+           <edition>2</edition>
+           <version>2000-01-01</version>
+           <language>en</language>
+           <script>Latn</script>
+           <status>
+             <stage>final-draft</stage>
+           </status>
+           <copyright>
+             <from>2001</from>
+             <owner>
+               <organization>
+                 <name>International Telecommunication Union</name>
+                 <abbreviation>ITU</abbreviation>
+               </organization>
+             </owner>
+           </copyright>
+           <relation type="complements">
+             <bibitem type="standard">
+               <title language="en" script="Latn" type="title-main">The international telex service – Service and operational provisions of telex destination codes and telex network identification codes</title>
+               <title language="en" script="Latn" type="main">The international telex service – Service and operational provisions of telex destination codes and telex network identification codes</title>
+               <uri type="src">https://handle.itu.int/11.1002/1000/696</uri>
+               <uri type="pdf">https://www.itu.int/rec/dologin_pub.asp?lang=e&amp;id=T-REC-F.69-199406-I!!PDF-E&amp;type=items</uri>
+               <docidentifier type="ITU" primary="true">ITU-T F.69</docidentifier>
+               <contributor>
+                 <role type="publisher"/>
+                 <organization>
                    <name>International Telecommunication Union</name>
                    <abbreviation>ITU</abbreviation>
-                </organization>
-             </contributor>
-             <contributor>
-                <role type="author"/>
-                <person>
-                   <name>
-                      <completename>Fred Flintstone</completename>
-                   </name>
-                </person>
-             </contributor>
-             <contributor>
-                <role type="editor"/>
-                <person>
-                   <name>
-                      <forename>Barney</forename>
-                      <surname>Rubble</surname>
-                   </name>
-                </person>
-             </contributor>
-             <contributor>
-                <role type="author">
+                   <uri>www.itu.int</uri>
+                 </organization>
+               </contributor>
+               <contributor>
+                 <role type="author">
                    <description>committee</description>
-                </role>
-                <organization>
+                 </role>
+                 <organization>
                    <name>International Telecommunication Union</name>
-                   <subdivision type="Bureau">
-                      <name>R</name>
+                   <subdivision type="technical-committee" subtype="study-group">
+                     <name>ITU-T Study Group 2</name>
                    </subdivision>
-                   <subdivision type="Sector">
-                      <name>Sector</name>
-                   </subdivision>
-                   <subdivision type="Group" subtype="A">
-                      <name>I</name>
-                      <identifier>C</identifier>
-                   </subdivision>
-                   <subdivision type="Subgroup" subtype="A1">
-                      <name>I1</name>
-                      <identifier>C1</identifier>
-                   </subdivision>
-                   <subdivision type="Workgroup" subtype="A2">
-                      <name>I2</name>
-                      <identifier>C2</identifier>
-                   </subdivision>
-                   <abbreviation>ITU</abbreviation>
-                </organization>
-             </contributor>
-             <contributor>
-                <role type="author">
-                   <description>committee</description>
-                </role>
-                <organization>
-                   <name>International Telecommunication Union</name>
-                   <subdivision type="Bureau">
-                      <name>T</name>
-                   </subdivision>
-                   <subdivision type="Group" subtype="B">
-                      <name>J</name>
-                      <identifier>D</identifier>
-                   </subdivision>
-                   <subdivision type="Subgroup" subtype="B1">
-                      <name>J1</name>
-                      <identifier>D1</identifier>
-                   </subdivision>
-                   <subdivision type="Workgroup" subtype="B2">
-                      <name>J2</name>
-                      <identifier>D2</identifier>
-                   </subdivision>
-                   <abbreviation>ITU</abbreviation>
-                </organization>
-             </contributor>
-             <contributor>
-                <role type="publisher"/>
-                <organization>
-                   <name>International Telecommunication Union</name>
-                   <abbreviation>ITU</abbreviation>
-                </organization>
-             </contributor>
-             <edition>2</edition>
-             <version>2000-01-01</version>
-             <language>en</language>
-             <script>Latn</script>
-             <status>
-                <stage>final-draft</stage>
-             </status>
-             <copyright>
-                <from>2001</from>
-                <owner>
+                   <abbreviation>ITU-T</abbreviation>
+                 </organization>
+               </contributor>
+               <edition>7</edition>
+               <language>en</language>
+               <script>Latn</script>
+               <status>
+                 <stage>Published</stage>
+               </status>
+               <copyright>
+                 <from>1994</from>
+                 <owner>
                    <organization>
-                      <name>International Telecommunication Union</name>
-                      <abbreviation>ITU</abbreviation>
+                     <name>International Telecommunication Union</name>
+                     <abbreviation>ITU</abbreviation>
+                     <uri>www.itu.int</uri>
                    </organization>
-                </owner>
-             </copyright>
-             <relation type="complements">
-                <bibitem type="standard">
-                   <title language="en" script="Latn" type="title-main">Plan for telex destination codes</title>
-                   <title language="en" script="Latn" type="main">Plan for telex destination codes</title>
-                   <uri type="src">https://handle.itu.int/11.1002/1000/694</uri>
-                   <uri type="pdf">https://www.itu.int/rec/dologin_pub.asp?lang=e&amp;id=T-REC-F.69-198811-S!!PDF-E&amp;type=items</uri>
-                   <docidentifier type="ITU" primary="true">ITU-T F.69</docidentifier>
+                 </owner>
+               </copyright>
+               <relation type="hasEdition">
+                 <bibitem>
+                   <title language="en" script="Latn">Plan for telex destination codes</title>
+                   <docidentifier type="ITU" primary="true">F.69 (03/1993)</docidentifier>
+                 </bibitem>
+               </relation>
+               <relation type="hasEdition">
+                 <bibitem>
+                   <title language="en" script="Latn">Plan for telex destination codes</title>
+                   <docidentifier type="ITU" primary="true">F.69 (11/1988)</docidentifier>
+                 </bibitem>
+               </relation>
+               <relation type="hasEdition">
+                 <bibitem>
+                   <title language="en" script="Latn">Plan for telex destination codes</title>
+                   <docidentifier type="ITU" primary="true">F.69 (10/1984)</docidentifier>
+                 </bibitem>
+               </relation>
+               <relation type="hasEdition">
+                 <bibitem>
+                   <title language="en" script="Latn">Plan for telex destination codes</title>
+                   <docidentifier type="ITU" primary="true">F.69 (11/1980)</docidentifier>
+                 </bibitem>
+               </relation>
+               <relation type="hasEdition">
+                 <bibitem>
+                   <formattedref>F.69 (1976) Amd. 1 (10/1977)</formattedref>
+                   <docidentifier type="ITU" primary="true">F.69 (1976) Amd. 1 (10/1977)</docidentifier>
+                 </bibitem>
+               </relation>
+               <relation type="hasEdition">
+                 <bibitem>
+                   <title language="en" script="Latn">Plan for telex destination codes</title>
+                   <docidentifier type="ITU" primary="true">F.69 (10/1976)</docidentifier>
+                 </bibitem>
+               </relation>
+               <relation type="hasEdition">
+                 <bibitem>
+                   <title language="en" script="Latn">Plan for telex destination codes</title>
+                   <docidentifier type="ITU" primary="true">F.69 (12/1972)</docidentifier>
+                 </bibitem>
+               </relation>
+               <relation type="complementOf">
+                 <bibitem>
+                   <title language="en" script="Latn">Definitions relating to telegraph, telematic and data transmission services</title>
+                   <docidentifier type="ITU" primary="true">F Suppl. 1 (11/1988)</docidentifier>
+                 </bibitem>
+               </relation>
+               <relation type="complementOf">
+                 <bibitem>
+                   <title language="en" script="Latn">Terms and definitions for telex</title>
+                   <docidentifier type="ITU" primary="true">F Suppl. 2 (11/1988)</docidentifier>
+                 </bibitem>
+               </relation>
+               <relation type="complementOf">
+                 <bibitem>
+                   <title language="en" script="Latn">Overview of Telecom Finance (Finance2.0)</title>
+                   <docidentifier type="ITU" primary="true">F Suppl. 3 (09/2016)</docidentifier>
+                 </bibitem>
+               </relation>
+               <relation type="complementOf">
+                 <bibitem>
+                   <title language="en" script="Latn">Overview of convergence of artificial intelligence and blockchain</title>
+                   <docidentifier type="ITU" primary="true">F Suppl. 4 (04/2021)</docidentifier>
+                 </bibitem>
+               </relation>
+               <relation type="instanceOf">
+                 <bibitem type="standard">
+                   <title language="en" script="Latn" type="title-main">The international telex service – Service and operational provisions of telex destination codes and telex network identification codes</title>
+                   <title language="en" script="Latn" type="main">The international telex service – Service and operational provisions of telex destination codes and telex network identification codes</title>
+                   <uri type="src">https://handle.itu.int/11.1002/1000/696</uri>
+                   <uri type="pdf">https://www.itu.int/rec/dologin_pub.asp?lang=e&amp;id=T-REC-F.69-199406-I!!PDF-E&amp;type=items</uri>
+                   <docidentifier type="ITU" primary="true">ITU-T F.69 (06/1994)</docidentifier>
+                   <date type="published">
+                     <on>1994-06-01</on>
+                   </date>
                    <contributor>
-                      <role type="publisher"/>
-                      <organization>
+                     <role type="publisher"/>
+                     <organization>
+                       <name>International Telecommunication Union</name>
+                       <abbreviation>ITU</abbreviation>
+                       <uri>www.itu.int</uri>
+                     </organization>
+                   </contributor>
+                   <contributor>
+                     <role type="author">
+                       <description>committee</description>
+                     </role>
+                     <organization>
+                       <name>International Telecommunication Union</name>
+                       <subdivision type="technical-committee" subtype="study-group">
+                         <name>ITU-T Study Group 2</name>
+                       </subdivision>
+                       <abbreviation>ITU-T</abbreviation>
+                     </organization>
+                   </contributor>
+                   <edition>7</edition>
+                   <language>en</language>
+                   <script>Latn</script>
+                   <abstract language="en" script="Latn">The interconnection of the networks of the countries and recognized operating agencies participating in the international telex service requires the development of a standardized mechanism for the routing of calls between subscribers in a transparent manner. This is achieved through the use of a telex destination code which is used for routing purposes in international exchanges. Telex destination codes may also be used within national telex networks or at international gateway exchanges for recording call details for billing and accounting purposes, or sometimes for other purposes such as segregating particular types of traffic. Furthermore, the service requirement enabling the identification of the called subscriber and thereby giving assurance of correct connection is achieved by the inclusion of a telex network identification code in the answerbacks of subscribers of the international telex service in addition to the subscribers national telex number.This Recommendation describes the procedures to be followed in the allocation of telex destination codes and telex network identification codes. The means of promulgation publication, and date of entry into effect of code allocations are also identified.</abstract>
+                   <status>
+                     <stage>Published</stage>
+                   </status>
+                   <copyright>
+                     <from>1994</from>
+                     <owner>
+                       <organization>
                          <name>International Telecommunication Union</name>
                          <abbreviation>ITU</abbreviation>
                          <uri>www.itu.int</uri>
-                      </organization>
-                   </contributor>
-                   <contributor>
-                      <role type="author">
-                         <description>committee</description>
-                      </role>
-                      <organization>
-                         <name>International Telecommunication Union</name>
-                         <subdivision type="technical-committee" subtype="study-group">
-                            <name>ITU-T Study Group 2</name>
-                         </subdivision>
-                         <abbreviation>ITU-T</abbreviation>
-                      </organization>
-                   </contributor>
-                   <edition>5</edition>
-                   <language>en</language>
-                   <script>Latn</script>
-                   <status>
-                      <stage>Withdrawal</stage>
-                   </status>
-                   <copyright>
-                      <from>1988</from>
-                      <owner>
-                         <organization>
-                            <name>International Telecommunication Union</name>
-                            <abbreviation>ITU</abbreviation>
-                            <uri>www.itu.int</uri>
-                         </organization>
-                      </owner>
+                       </organization>
+                     </owner>
                    </copyright>
                    <relation type="hasEdition">
-                      <bibitem>
-                         <title language="en" script="Latn">The international telex service – Service and operational provisions of telex destination codes and telex network identification codes</title>
-                         <docidentifier type="ITU" primary="true">F.69 (06/1994)</docidentifier>
-                      </bibitem>
+                     <bibitem>
+                       <title language="en" script="Latn">Plan for telex destination codes</title>
+                       <docidentifier type="ITU" primary="true">F.69 (03/1993)</docidentifier>
+                     </bibitem>
                    </relation>
                    <relation type="hasEdition">
-                      <bibitem>
-                         <title language="en" script="Latn">Plan for telex destination codes</title>
-                         <docidentifier type="ITU" primary="true">F.69 (03/1993)</docidentifier>
-                      </bibitem>
+                     <bibitem>
+                       <title language="en" script="Latn">Plan for telex destination codes</title>
+                       <docidentifier type="ITU" primary="true">F.69 (11/1988)</docidentifier>
+                     </bibitem>
                    </relation>
                    <relation type="hasEdition">
-                      <bibitem>
-                         <title language="en" script="Latn">Plan for telex destination codes</title>
-                         <docidentifier type="ITU" primary="true">F.69 (10/1984)</docidentifier>
-                      </bibitem>
+                     <bibitem>
+                       <title language="en" script="Latn">Plan for telex destination codes</title>
+                       <docidentifier type="ITU" primary="true">F.69 (10/1984)</docidentifier>
+                     </bibitem>
                    </relation>
                    <relation type="hasEdition">
-                      <bibitem>
-                         <title language="en" script="Latn">Plan for telex destination codes</title>
-                         <docidentifier type="ITU" primary="true">F.69 (11/1980)</docidentifier>
-                      </bibitem>
+                     <bibitem>
+                       <title language="en" script="Latn">Plan for telex destination codes</title>
+                       <docidentifier type="ITU" primary="true">F.69 (11/1980)</docidentifier>
+                     </bibitem>
                    </relation>
                    <relation type="hasEdition">
-                      <bibitem>
-                         <formattedref>F.69 (1976) Amd. 1 (10/1977)</formattedref>
-                         <docidentifier type="ITU" primary="true">F.69 (1976) Amd. 1 (10/1977)</docidentifier>
-                      </bibitem>
+                     <bibitem>
+                       <formattedref>F.69 (1976) Amd. 1 (10/1977)</formattedref>
+                       <docidentifier type="ITU" primary="true">F.69 (1976) Amd. 1 (10/1977)</docidentifier>
+                     </bibitem>
                    </relation>
                    <relation type="hasEdition">
-                      <bibitem>
-                         <title language="en" script="Latn">Plan for telex destination codes</title>
-                         <docidentifier type="ITU" primary="true">F.69 (10/1976)</docidentifier>
-                      </bibitem>
+                     <bibitem>
+                       <title language="en" script="Latn">Plan for telex destination codes</title>
+                       <docidentifier type="ITU" primary="true">F.69 (10/1976)</docidentifier>
+                     </bibitem>
                    </relation>
                    <relation type="hasEdition">
-                      <bibitem>
-                         <title language="en" script="Latn">Plan for telex destination codes</title>
-                         <docidentifier type="ITU" primary="true">F.69 (12/1972)</docidentifier>
-                      </bibitem>
+                     <bibitem>
+                       <title language="en" script="Latn">Plan for telex destination codes</title>
+                       <docidentifier type="ITU" primary="true">F.69 (12/1972)</docidentifier>
+                     </bibitem>
                    </relation>
                    <relation type="complementOf">
-                      <bibitem>
-                         <title language="en" script="Latn">Definitions relating to telegraph, telematic and data transmission services</title>
-                         <docidentifier type="ITU" primary="true">F Suppl. 1 (11/1988)</docidentifier>
-                      </bibitem>
+                     <bibitem>
+                       <title language="en" script="Latn">Definitions relating to telegraph, telematic and data transmission services</title>
+                       <docidentifier type="ITU" primary="true">F Suppl. 1 (11/1988)</docidentifier>
+                     </bibitem>
                    </relation>
                    <relation type="complementOf">
-                      <bibitem>
-                         <title language="en" script="Latn">Terms and definitions for telex</title>
-                         <docidentifier type="ITU" primary="true">F Suppl. 2 (11/1988)</docidentifier>
-                      </bibitem>
+                     <bibitem>
+                       <title language="en" script="Latn">Terms and definitions for telex</title>
+                       <docidentifier type="ITU" primary="true">F Suppl. 2 (11/1988)</docidentifier>
+                     </bibitem>
                    </relation>
                    <relation type="complementOf">
-                      <bibitem>
-                         <title language="en" script="Latn">Overview of Telecom Finance (Finance2.0)</title>
-                         <docidentifier type="ITU" primary="true">F Suppl. 3 (09/2016)</docidentifier>
-                      </bibitem>
+                     <bibitem>
+                       <title language="en" script="Latn">Overview of Telecom Finance (Finance2.0)</title>
+                       <docidentifier type="ITU" primary="true">F Suppl. 3 (09/2016)</docidentifier>
+                     </bibitem>
                    </relation>
                    <relation type="complementOf">
-                      <bibitem>
-                         <title language="en" script="Latn">Overview of convergence of artificial intelligence and blockchain</title>
-                         <docidentifier type="ITU" primary="true">F Suppl. 4 (04/2021)</docidentifier>
-                      </bibitem>
-                   </relation>
-                   <relation type="instanceOf">
-                      <bibitem type="standard">
-                         <title language="en" script="Latn" type="title-main">Plan for telex destination codes</title>
-                         <title language="en" script="Latn" type="main">Plan for telex destination codes</title>
-                         <uri type="src">https://handle.itu.int/11.1002/1000/694</uri>
-                         <uri type="pdf">https://www.itu.int/rec/dologin_pub.asp?lang=e&amp;id=T-REC-F.69-198811-S!!PDF-E&amp;type=items</uri>
-                         <docidentifier type="ITU" primary="true">ITU-T F.69 (11/1988)</docidentifier>
-                         <date type="published">
-                            <on>1988-11-25</on>
-                         </date>
-                         <contributor>
-                            <role type="publisher"/>
-                            <organization>
-                               <name>International Telecommunication Union</name>
-                               <abbreviation>ITU</abbreviation>
-                               <uri>www.itu.int</uri>
-                            </organization>
-                         </contributor>
-                         <contributor>
-                            <role type="author">
-                               <description>committee</description>
-                            </role>
-                            <organization>
-                               <name>International Telecommunication Union</name>
-                               <subdivision type="technical-committee" subtype="study-group">
-                                  <name>ITU-T Study Group 2</name>
-                               </subdivision>
-                               <abbreviation>ITU-T</abbreviation>
-                            </organization>
-                         </contributor>
-                         <edition>5</edition>
-                         <language>en</language>
-                         <script>Latn</script>
-                         <abstract language="en" script="Latn"/>
-                         <status>
-                            <stage>Withdrawal</stage>
-                         </status>
-                         <copyright>
-                            <from>1988</from>
-                            <owner>
-                               <organization>
-                                  <name>International Telecommunication Union</name>
-                                  <abbreviation>ITU</abbreviation>
-                                  <uri>www.itu.int</uri>
-                               </organization>
-                            </owner>
-                         </copyright>
-                         <relation type="hasEdition">
-                            <bibitem>
-                               <title language="en" script="Latn">The international telex service – Service and operational provisions of telex destination codes and telex network identification codes</title>
-                               <docidentifier type="ITU" primary="true">F.69 (06/1994)</docidentifier>
-                            </bibitem>
-                         </relation>
-                         <relation type="hasEdition">
-                            <bibitem>
-                               <title language="en" script="Latn">Plan for telex destination codes</title>
-                               <docidentifier type="ITU" primary="true">F.69 (03/1993)</docidentifier>
-                            </bibitem>
-                         </relation>
-                         <relation type="hasEdition">
-                            <bibitem>
-                               <title language="en" script="Latn">Plan for telex destination codes</title>
-                               <docidentifier type="ITU" primary="true">F.69 (10/1984)</docidentifier>
-                            </bibitem>
-                         </relation>
-                         <relation type="hasEdition">
-                            <bibitem>
-                               <title language="en" script="Latn">Plan for telex destination codes</title>
-                               <docidentifier type="ITU" primary="true">F.69 (11/1980)</docidentifier>
-                            </bibitem>
-                         </relation>
-                         <relation type="hasEdition">
-                            <bibitem>
-                               <formattedref>F.69 (1976) Amd. 1 (10/1977)</formattedref>
-                               <docidentifier type="ITU" primary="true">F.69 (1976) Amd. 1 (10/1977)</docidentifier>
-                            </bibitem>
-                         </relation>
-                         <relation type="hasEdition">
-                            <bibitem>
-                               <title language="en" script="Latn">Plan for telex destination codes</title>
-                               <docidentifier type="ITU" primary="true">F.69 (10/1976)</docidentifier>
-                            </bibitem>
-                         </relation>
-                         <relation type="hasEdition">
-                            <bibitem>
-                               <title language="en" script="Latn">Plan for telex destination codes</title>
-                               <docidentifier type="ITU" primary="true">F.69 (12/1972)</docidentifier>
-                            </bibitem>
-                         </relation>
-                         <relation type="complementOf">
-                            <bibitem>
-                               <title language="en" script="Latn">Definitions relating to telegraph, telematic and data transmission services</title>
-                               <docidentifier type="ITU" primary="true">F Suppl. 1 (11/1988)</docidentifier>
-                            </bibitem>
-                         </relation>
-                         <relation type="complementOf">
-                            <bibitem>
-                               <title language="en" script="Latn">Terms and definitions for telex</title>
-                               <docidentifier type="ITU" primary="true">F Suppl. 2 (11/1988)</docidentifier>
-                            </bibitem>
-                         </relation>
-                         <relation type="complementOf">
-                            <bibitem>
-                               <title language="en" script="Latn">Overview of Telecom Finance (Finance2.0)</title>
-                               <docidentifier type="ITU" primary="true">F Suppl. 3 (09/2016)</docidentifier>
-                            </bibitem>
-                         </relation>
-                         <relation type="complementOf">
-                            <bibitem>
-                               <title language="en" script="Latn">Overview of convergence of artificial intelligence and blockchain</title>
-                               <docidentifier type="ITU" primary="true">F Suppl. 4 (04/2021)</docidentifier>
-                            </bibitem>
-                         </relation>
-                         <place>
-                            <city>Geneva</city>
-                         </place>
-                      </bibitem>
+                     <bibitem>
+                       <title language="en" script="Latn">Overview of convergence of artificial intelligence and blockchain</title>
+                       <docidentifier type="ITU" primary="true">F Suppl. 4 (04/2021)</docidentifier>
+                     </bibitem>
                    </relation>
                    <place>
-                      <city>Geneva</city>
+                     <city>Geneva</city>
                    </place>
-                </bibitem>
-             </relation>
-             <relation type="complements">
-                <bibitem type="standard">
+                 </bibitem>
+               </relation>
+               <place>
+                 <city>Geneva</city>
+               </place>
+             </bibitem>
+           </relation>
+           <relation type="complements">
+             <bibitem type="standard">
+               <title language="en" script="Latn" type="title-main">Establishment of the automatic intercontinental telex network</title>
+               <title language="en" script="Latn" type="main">Establishment of the automatic intercontinental telex network</title>
+               <uri type="src">https://handle.itu.int/11.1002/1000/693</uri>
+               <uri type="pdf">https://www.itu.int/rec/dologin_pub.asp?lang=e&amp;id=T-REC-F.68-198811-I!!PDF-E&amp;type=items</uri>
+               <docidentifier type="ITU" primary="true">ITU-T F.68</docidentifier>
+               <contributor>
+                 <role type="publisher"/>
+                 <organization>
+                   <name>International Telecommunication Union</name>
+                   <abbreviation>ITU</abbreviation>
+                   <uri>www.itu.int</uri>
+                 </organization>
+               </contributor>
+               <contributor>
+                 <role type="author">
+                   <description>committee</description>
+                 </role>
+                 <organization>
+                   <name>International Telecommunication Union</name>
+                   <subdivision type="technical-committee" subtype="study-group">
+                     <name>ITU-T Study Group 2</name>
+                   </subdivision>
+                   <abbreviation>ITU-T</abbreviation>
+                 </organization>
+               </contributor>
+               <edition>5</edition>
+               <language>en</language>
+               <script>Latn</script>
+               <status>
+                 <stage>Published</stage>
+               </status>
+               <copyright>
+                 <from>1988</from>
+                 <owner>
+                   <organization>
+                     <name>International Telecommunication Union</name>
+                     <abbreviation>ITU</abbreviation>
+                     <uri>www.itu.int</uri>
+                   </organization>
+                 </owner>
+               </copyright>
+               <relation type="hasEdition">
+                 <bibitem>
+                   <title language="en" script="Latn">Establishment of the automatic intercontinental telex network</title>
+                   <docidentifier type="ITU" primary="true">F.68 (10/1984)</docidentifier>
+                 </bibitem>
+               </relation>
+               <relation type="hasEdition">
+                 <bibitem>
+                   <title language="en" script="Latn">Establishment of the automatic intercontinental telex network</title>
+                   <docidentifier type="ITU" primary="true">F.68 (11/1980)</docidentifier>
+                 </bibitem>
+               </relation>
+               <relation type="hasEdition">
+                 <bibitem>
+                   <title language="en" script="Latn">Establishment of the automatic intercontinental telex network</title>
+                   <docidentifier type="ITU" primary="true">F.68 (10/1976)</docidentifier>
+                 </bibitem>
+               </relation>
+               <relation type="hasEdition">
+                 <bibitem>
+                   <title language="en" script="Latn">Establishment of the automatic intercontinental telex network</title>
+                   <docidentifier type="ITU" primary="true">F.68 (12/1972)</docidentifier>
+                 </bibitem>
+               </relation>
+               <relation type="complementOf">
+                 <bibitem>
+                   <title language="en" script="Latn">Definitions relating to telegraph, telematic and data transmission services</title>
+                   <docidentifier type="ITU" primary="true">F Suppl. 1 (11/1988)</docidentifier>
+                 </bibitem>
+               </relation>
+               <relation type="complementOf">
+                 <bibitem>
+                   <title language="en" script="Latn">Terms and definitions for telex</title>
+                   <docidentifier type="ITU" primary="true">F Suppl. 2 (11/1988)</docidentifier>
+                 </bibitem>
+               </relation>
+               <relation type="complementOf">
+                 <bibitem>
+                   <title language="en" script="Latn">Overview of Telecom Finance (Finance2.0)</title>
+                   <docidentifier type="ITU" primary="true">F Suppl. 3 (09/2016)</docidentifier>
+                 </bibitem>
+               </relation>
+               <relation type="complementOf">
+                 <bibitem>
+                   <title language="en" script="Latn">Overview of convergence of artificial intelligence and blockchain</title>
+                   <docidentifier type="ITU" primary="true">F Suppl. 4 (04/2021)</docidentifier>
+                 </bibitem>
+               </relation>
+               <relation type="instanceOf">
+                 <bibitem type="standard">
                    <title language="en" script="Latn" type="title-main">Establishment of the automatic intercontinental telex network</title>
                    <title language="en" script="Latn" type="main">Establishment of the automatic intercontinental telex network</title>
                    <uri type="src">https://handle.itu.int/11.1002/1000/693</uri>
                    <uri type="pdf">https://www.itu.int/rec/dologin_pub.asp?lang=e&amp;id=T-REC-F.68-198811-I!!PDF-E&amp;type=items</uri>
-                   <docidentifier type="ITU" primary="true">ITU-T F.68</docidentifier>
+                   <docidentifier type="ITU" primary="true">ITU-T F.68 (11/1988)</docidentifier>
+                   <date type="published">
+                     <on>1988-11-25</on>
+                   </date>
                    <contributor>
-                      <role type="publisher"/>
-                      <organization>
-                         <name>International Telecommunication Union</name>
-                         <abbreviation>ITU</abbreviation>
-                         <uri>www.itu.int</uri>
-                      </organization>
+                     <role type="publisher"/>
+                     <organization>
+                       <name>International Telecommunication Union</name>
+                       <abbreviation>ITU</abbreviation>
+                       <uri>www.itu.int</uri>
+                     </organization>
                    </contributor>
                    <contributor>
-                      <role type="author">
-                         <description>committee</description>
-                      </role>
-                      <organization>
-                         <name>International Telecommunication Union</name>
-                         <subdivision type="technical-committee" subtype="study-group">
-                            <name>ITU-T Study Group 2</name>
-                         </subdivision>
-                         <abbreviation>ITU-T</abbreviation>
-                      </organization>
+                     <role type="author">
+                       <description>committee</description>
+                     </role>
+                     <organization>
+                       <name>International Telecommunication Union</name>
+                       <subdivision type="technical-committee" subtype="study-group">
+                         <name>ITU-T Study Group 2</name>
+                       </subdivision>
+                       <abbreviation>ITU-T</abbreviation>
+                     </organization>
                    </contributor>
                    <edition>5</edition>
                    <language>en</language>
                    <script>Latn</script>
+                   <abstract language="en" script="Latn"/>
                    <status>
-                      <stage>Published</stage>
+                     <stage>Published</stage>
                    </status>
                    <copyright>
-                      <from>1988</from>
-                      <owner>
-                         <organization>
-                            <name>International Telecommunication Union</name>
-                            <abbreviation>ITU</abbreviation>
-                            <uri>www.itu.int</uri>
-                         </organization>
-                      </owner>
+                     <from>1988</from>
+                     <owner>
+                       <organization>
+                         <name>International Telecommunication Union</name>
+                         <abbreviation>ITU</abbreviation>
+                         <uri>www.itu.int</uri>
+                       </organization>
+                     </owner>
                    </copyright>
                    <relation type="hasEdition">
-                      <bibitem>
-                         <title language="en" script="Latn">Establishment of the automatic intercontinental telex network</title>
-                         <docidentifier type="ITU" primary="true">F.68 (10/1984)</docidentifier>
-                      </bibitem>
+                     <bibitem>
+                       <title language="en" script="Latn">Establishment of the automatic intercontinental telex network</title>
+                       <docidentifier type="ITU" primary="true">F.68 (10/1984)</docidentifier>
+                     </bibitem>
                    </relation>
                    <relation type="hasEdition">
-                      <bibitem>
-                         <title language="en" script="Latn">Establishment of the automatic intercontinental telex network</title>
-                         <docidentifier type="ITU" primary="true">F.68 (11/1980)</docidentifier>
-                      </bibitem>
+                     <bibitem>
+                       <title language="en" script="Latn">Establishment of the automatic intercontinental telex network</title>
+                       <docidentifier type="ITU" primary="true">F.68 (11/1980)</docidentifier>
+                     </bibitem>
                    </relation>
                    <relation type="hasEdition">
-                      <bibitem>
-                         <title language="en" script="Latn">Establishment of the automatic intercontinental telex network</title>
-                         <docidentifier type="ITU" primary="true">F.68 (10/1976)</docidentifier>
-                      </bibitem>
+                     <bibitem>
+                       <title language="en" script="Latn">Establishment of the automatic intercontinental telex network</title>
+                       <docidentifier type="ITU" primary="true">F.68 (10/1976)</docidentifier>
+                     </bibitem>
                    </relation>
                    <relation type="hasEdition">
-                      <bibitem>
-                         <title language="en" script="Latn">Establishment of the automatic intercontinental telex network</title>
-                         <docidentifier type="ITU" primary="true">F.68 (12/1972)</docidentifier>
-                      </bibitem>
+                     <bibitem>
+                       <title language="en" script="Latn">Establishment of the automatic intercontinental telex network</title>
+                       <docidentifier type="ITU" primary="true">F.68 (12/1972)</docidentifier>
+                     </bibitem>
                    </relation>
                    <relation type="complementOf">
-                      <bibitem>
-                         <title language="en" script="Latn">Definitions relating to telegraph, telematic and data transmission services</title>
-                         <docidentifier type="ITU" primary="true">F Suppl. 1 (11/1988)</docidentifier>
-                      </bibitem>
+                     <bibitem>
+                       <title language="en" script="Latn">Definitions relating to telegraph, telematic and data transmission services</title>
+                       <docidentifier type="ITU" primary="true">F Suppl. 1 (11/1988)</docidentifier>
+                     </bibitem>
                    </relation>
                    <relation type="complementOf">
-                      <bibitem>
-                         <title language="en" script="Latn">Terms and definitions for telex</title>
-                         <docidentifier type="ITU" primary="true">F Suppl. 2 (11/1988)</docidentifier>
-                      </bibitem>
+                     <bibitem>
+                       <title language="en" script="Latn">Terms and definitions for telex</title>
+                       <docidentifier type="ITU" primary="true">F Suppl. 2 (11/1988)</docidentifier>
+                     </bibitem>
                    </relation>
                    <relation type="complementOf">
-                      <bibitem>
-                         <title language="en" script="Latn">Overview of Telecom Finance (Finance2.0)</title>
-                         <docidentifier type="ITU" primary="true">F Suppl. 3 (09/2016)</docidentifier>
-                      </bibitem>
+                     <bibitem>
+                       <title language="en" script="Latn">Overview of Telecom Finance (Finance2.0)</title>
+                       <docidentifier type="ITU" primary="true">F Suppl. 3 (09/2016)</docidentifier>
+                     </bibitem>
                    </relation>
                    <relation type="complementOf">
-                      <bibitem>
-                         <title language="en" script="Latn">Overview of convergence of artificial intelligence and blockchain</title>
-                         <docidentifier type="ITU" primary="true">F Suppl. 4 (04/2021)</docidentifier>
-                      </bibitem>
-                   </relation>
-                   <relation type="instanceOf">
-                      <bibitem type="standard">
-                         <title language="en" script="Latn" type="title-main">Establishment of the automatic intercontinental telex network</title>
-                         <title language="en" script="Latn" type="main">Establishment of the automatic intercontinental telex network</title>
-                         <uri type="src">https://handle.itu.int/11.1002/1000/693</uri>
-                         <uri type="pdf">https://www.itu.int/rec/dologin_pub.asp?lang=e&amp;id=T-REC-F.68-198811-I!!PDF-E&amp;type=items</uri>
-                         <docidentifier type="ITU" primary="true">ITU-T F.68 (11/1988)</docidentifier>
-                         <date type="published">
-                            <on>1988-11-25</on>
-                         </date>
-                         <contributor>
-                            <role type="publisher"/>
-                            <organization>
-                               <name>International Telecommunication Union</name>
-                               <abbreviation>ITU</abbreviation>
-                               <uri>www.itu.int</uri>
-                            </organization>
-                         </contributor>
-                         <contributor>
-                            <role type="author">
-                               <description>committee</description>
-                            </role>
-                            <organization>
-                               <name>International Telecommunication Union</name>
-                               <subdivision type="technical-committee" subtype="study-group">
-                                  <name>ITU-T Study Group 2</name>
-                               </subdivision>
-                               <abbreviation>ITU-T</abbreviation>
-                            </organization>
-                         </contributor>
-                         <edition>5</edition>
-                         <language>en</language>
-                         <script>Latn</script>
-                         <abstract language="en" script="Latn"/>
-                         <status>
-                            <stage>Published</stage>
-                         </status>
-                         <copyright>
-                            <from>1988</from>
-                            <owner>
-                               <organization>
-                                  <name>International Telecommunication Union</name>
-                                  <abbreviation>ITU</abbreviation>
-                                  <uri>www.itu.int</uri>
-                               </organization>
-                            </owner>
-                         </copyright>
-                         <relation type="hasEdition">
-                            <bibitem>
-                               <title language="en" script="Latn">Establishment of the automatic intercontinental telex network</title>
-                               <docidentifier type="ITU" primary="true">F.68 (10/1984)</docidentifier>
-                            </bibitem>
-                         </relation>
-                         <relation type="hasEdition">
-                            <bibitem>
-                               <title language="en" script="Latn">Establishment of the automatic intercontinental telex network</title>
-                               <docidentifier type="ITU" primary="true">F.68 (11/1980)</docidentifier>
-                            </bibitem>
-                         </relation>
-                         <relation type="hasEdition">
-                            <bibitem>
-                               <title language="en" script="Latn">Establishment of the automatic intercontinental telex network</title>
-                               <docidentifier type="ITU" primary="true">F.68 (10/1976)</docidentifier>
-                            </bibitem>
-                         </relation>
-                         <relation type="hasEdition">
-                            <bibitem>
-                               <title language="en" script="Latn">Establishment of the automatic intercontinental telex network</title>
-                               <docidentifier type="ITU" primary="true">F.68 (12/1972)</docidentifier>
-                            </bibitem>
-                         </relation>
-                         <relation type="complementOf">
-                            <bibitem>
-                               <title language="en" script="Latn">Definitions relating to telegraph, telematic and data transmission services</title>
-                               <docidentifier type="ITU" primary="true">F Suppl. 1 (11/1988)</docidentifier>
-                            </bibitem>
-                         </relation>
-                         <relation type="complementOf">
-                            <bibitem>
-                               <title language="en" script="Latn">Terms and definitions for telex</title>
-                               <docidentifier type="ITU" primary="true">F Suppl. 2 (11/1988)</docidentifier>
-                            </bibitem>
-                         </relation>
-                         <relation type="complementOf">
-                            <bibitem>
-                               <title language="en" script="Latn">Overview of Telecom Finance (Finance2.0)</title>
-                               <docidentifier type="ITU" primary="true">F Suppl. 3 (09/2016)</docidentifier>
-                            </bibitem>
-                         </relation>
-                         <relation type="complementOf">
-                            <bibitem>
-                               <title language="en" script="Latn">Overview of convergence of artificial intelligence and blockchain</title>
-                               <docidentifier type="ITU" primary="true">F Suppl. 4 (04/2021)</docidentifier>
-                            </bibitem>
-                         </relation>
-                         <place>
-                            <city>Geneva</city>
-                         </place>
-                      </bibitem>
+                     <bibitem>
+                       <title language="en" script="Latn">Overview of convergence of artificial intelligence and blockchain</title>
+                       <docidentifier type="ITU" primary="true">F Suppl. 4 (04/2021)</docidentifier>
+                     </bibitem>
                    </relation>
                    <place>
-                      <city>Geneva</city>
+                     <city>Geneva</city>
                    </place>
-                </bibitem>
-             </relation>
-             <series type="main">
-                <title>A3</title>
-             </series>
-             <series type="secondary">
-                <title>B3</title>
-             </series>
-             <series type="tertiary">
-                <title>C3</title>
-             </series>
-             <keyword><vocab>Word1</vocab></keyword>
-             <keyword><vocab>word2</vocab></keyword>
-             <ext>
-                <doctype>directive</doctype>
-                <flavor>itu</flavor>
-                <structuredidentifier>
-                   <bureau>R</bureau>
-                   <docnumber>1000</docnumber>
-                   <annexid>H3</annexid>
-                   <amendment>88</amendment>
-                   <corrigendum>88</corrigendum>
-                </structuredidentifier>
-                <question>
-                   <identifier>Q10/17</identifier>
-                   <name>Identity management and telebiometrics architecture and mechanisms</name>
-                </question>
-                <question>
-                   <identifier>Q11/17</identifier>
-                   <name>Generic technologies (such as Directory, PKI, formal languages, object identifiers) to support secure applications</name>
-                </question>
-                <recommendationstatus>
-                   <from>D3</from>
-                   <to>E3</to>
-                   <approvalstage process="F3">G3</approvalstage>
-                </recommendationstatus>
-                <ip-notice-received>false</ip-notice-received>
-                <studyperiod>
-                   <start>E</start>
-                   <end>G</end>
-                </studyperiod>
-                <timing>2025-Q4</timing>
-             </ext>
-          </bibdata>
-          <metanorma-extension>
-             <semantic-metadata>
-                <stage-published>true</stage-published>
-             </semantic-metadata>
-             <presentation-metadata>
-                <document-scheme>legacy</document-scheme>
-                <coverpage-image>
-                   <image src="images/image1.gif"/>
-                   <image src="images/image2.gif"/>
-                </coverpage-image>
-                <toc-heading-levels>2</toc-heading-levels>
-                <html-toc-heading-levels>2</html-toc-heading-levels>
-                <doc-toc-heading-levels>2</doc-toc-heading-levels>
-                <pdf-toc-heading-levels>2</pdf-toc-heading-levels>
-             </presentation-metadata>
-          </metanorma-extension>
-          <sections> </sections>
+                 </bibitem>
+               </relation>
+               <place>
+                 <city>Geneva</city>
+               </place>
+             </bibitem>
+           </relation>
+           <series type="main">
+             <title>A3</title>
+           </series>
+           <series type="secondary">
+             <title>B3</title>
+           </series>
+           <series type="tertiary">
+             <title>C3</title>
+           </series>
+           <keyword>
+             <vocab>Word1</vocab>
+           </keyword>
+           <keyword>
+             <vocab>word2</vocab>
+           </keyword>
+           <ext>
+             <doctype>directive</doctype>
+             <flavor>itu</flavor>
+             <structuredidentifier>
+               <bureau>R</bureau>
+               <docnumber>1000</docnumber>
+               <annexid>H3</annexid>
+               <amendment>88</amendment>
+               <corrigendum>88</corrigendum>
+             </structuredidentifier>
+             <question>
+               <identifier>Q10/17</identifier>
+               <name>Identity management and telebiometrics architecture and mechanisms</name>
+             </question>
+             <question>
+               <identifier>Q11/17</identifier>
+               <name>Generic technologies (such as Directory, PKI, formal languages, object identifiers) to support secure applications</name>
+             </question>
+             <recommendationstatus>
+               <from>D3</from>
+               <to>E3</to>
+               <approvalstage process="F3">G3</approvalstage>
+             </recommendationstatus>
+             <ip-notice-received>false</ip-notice-received>
+             <studyperiod>
+               <start>E</start>
+               <end>G</end>
+             </studyperiod>
+             <timing>2025-Q4</timing>
+           </ext>
+         </bibdata>
+         <metanorma-extension>
+           <semantic-metadata>
+             <stage-published>true</stage-published>
+           </semantic-metadata>
+           <presentation-metadata>
+             <document-scheme>legacy</document-scheme>
+             <coverpage-image>
+               <image src="images/image1.gif"/>
+               <image src="images/image2.gif"/>
+             </coverpage-image>
+             <toc-heading-levels>2</toc-heading-levels>
+             <html-toc-heading-levels>2</html-toc-heading-levels>
+             <doc-toc-heading-levels>2</doc-toc-heading-levels>
+             <pdf-toc-heading-levels>2</pdf-toc-heading-levels>
+           </presentation-metadata>
+         </metanorma-extension>
+         <sections> </sections>
        </metanorma>
     OUTPUT
     xml.xpath("//xmlns:boilerplate | //xmlns:fetched")

--- a/spec/metanorma/base_spec.rb
+++ b/spec/metanorma/base_spec.rb
@@ -799,8 +799,8 @@ RSpec.describe Metanorma::Itu do
              <series type="tertiary">
                 <title>C3</title>
              </series>
-             <keyword>Word1</keyword>
-             <keyword>word2</keyword>
+             <keyword><vocab>Word1</vocab></keyword>
+             <keyword><vocab>word2</vocab></keyword>
              <ext>
                 <doctype>directive</doctype>
                 <flavor>itu</flavor>
@@ -1116,8 +1116,8 @@ RSpec.describe Metanorma::Itu do
           <series type='tertiary'>
             <title>C3</title>
           </series>
-          <keyword>VoIP</keyword>
-          <keyword>word1</keyword>
+          <keyword><vocab>VoIP</vocab></keyword>
+          <keyword><vocab>word1</vocab></keyword>
           <ext>
             <doctype>contribution</doctype>
             <flavor>itu</flavor>
@@ -1320,8 +1320,8 @@ RSpec.describe Metanorma::Itu do
           <series type='tertiary'>
             <title>C3</title>
           </series>
-          <keyword>VoIP</keyword>
-          <keyword>word1</keyword>
+          <keyword><vocab>VoIP</vocab></keyword>
+          <keyword><vocab>word1</vocab></keyword>
           <ext>
             <doctype>technical-report</doctype>
             <flavor>itu</flavor>
@@ -1462,8 +1462,8 @@ RSpec.describe Metanorma::Itu do
           <series type='tertiary'>
             <title>C3</title>
           </series>
-          <keyword>Word1</keyword>
-          <keyword>word2</keyword>
+          <keyword><vocab>Word1</vocab></keyword>
+          <keyword><vocab>word2</vocab></keyword>
           <ext>
             <doctype>technical-report</doctype>
             <flavor>itu</flavor>
@@ -1655,8 +1655,8 @@ RSpec.describe Metanorma::Itu do
            <series type='tertiary'>
              <title>C3</title>
            </series>
-           <keyword>Word1</keyword>
-           <keyword>word2</keyword>
+           <keyword><vocab>Word1</vocab></keyword>
+           <keyword><vocab>word2</vocab></keyword>
            <ext>
              <doctype>service-publication</doctype>
              <flavor>itu</flavor>

--- a/spec/metanorma/i18n_spec.rb
+++ b/spec/metanorma/i18n_spec.rb
@@ -168,8 +168,8 @@ RSpec.describe Metanorma::Itu do
            <series type="tertiary">
              <title>C3</title>
            </series>
-           <keyword>Word1</keyword>
-           <keyword>word2</keyword>
+           <keyword><vocab>Word1</vocab></keyword>
+           <keyword><vocab>word2</vocab></keyword>
           <ext>
             <doctype>service-publication</doctype>
             <flavor>itu</flavor>
@@ -544,8 +544,8 @@ RSpec.describe Metanorma::Itu do
            <series type="tertiary">
              <title>C3</title>
            </series>
-           <keyword>Word1</keyword>
-           <keyword>word2</keyword>
+           <keyword><vocab>Word1</vocab></keyword>
+           <keyword><vocab>word2</vocab></keyword>
           <ext>
             <doctype>service-publication</doctype>
             <flavor>itu</flavor>
@@ -895,8 +895,8 @@ RSpec.describe Metanorma::Itu do
            <series type="tertiary">
              <title>C3</title>
            </series>
-           <keyword>Word1</keyword>
-           <keyword>word2</keyword>
+           <keyword><vocab>Word1</vocab></keyword>
+           <keyword><vocab>word2</vocab></keyword>
         <ext>
           <doctype>service-publication</doctype>
             <flavor>itu</flavor>
@@ -1250,8 +1250,8 @@ RSpec.describe Metanorma::Itu do
            <series type="tertiary">
              <title>C3</title>
            </series>
-           <keyword>Word1</keyword>
-           <keyword>word2</keyword>
+           <keyword><vocab>Word1</vocab></keyword>
+           <keyword><vocab>word2</vocab></keyword>
         <ext>
           <doctype>service-publication</doctype>
             <flavor>itu</flavor>
@@ -1604,8 +1604,8 @@ RSpec.describe Metanorma::Itu do
            <series type="tertiary">
              <title>C3</title>
            </series>
-           <keyword>Word1</keyword>
-           <keyword>word2</keyword>
+           <keyword><vocab>Word1</vocab></keyword>
+           <keyword><vocab>word2</vocab></keyword>
         <ext>
           <doctype>service-publication</doctype>
             <flavor>itu</flavor>
@@ -1957,8 +1957,8 @@ RSpec.describe Metanorma::Itu do
            <series type="tertiary">
              <title>C3</title>
            </series>
-           <keyword>Word1</keyword>
-           <keyword>word2</keyword>
+           <keyword><vocab>Word1</vocab></keyword>
+           <keyword><vocab>word2</vocab></keyword>
             <ext>
               <doctype>service-publication</doctype>
              <flavor>itu</flavor>


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-iso/issues/513

ITU half of the structured-keywords fix (companion to metanorma-standoc#1220): the metadata_keywords override wrote bare text into the structured keyword model; uncontrolled keywords now wrap in `<vocab>`. Spec expectations updated (semantic inputs and semantic->presentation outputs carry the wrap; presentation-XML-input fixtures and the inline `<keyword>` element are untouched). Full suite: 144 examples, 2 failures — both reproduce on clean main (`processes explicit metadata`, `reorders references in bibliography`), pre-existing and out of scope.

🤖
